### PR TITLE
GeoMesaIngestProcessor hang fix.

### DIFF
--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -65,10 +65,10 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
 
 //Added Try and ruok error-checking here
     try {    
-      val zookeepers = context.getProperty(Zookeepers).getValue
-      val nc_host = "nc " + zookeepers.replace(':', ' ')
-      val ret = ("echo ruok" #| nc_host)!!
-      val zoo_run = if (ret == "imok") {
+//      val zookeepers = context.getProperty(Zookeepers).getValue
+//      val nc_host = "nc " + zookeepers.replace(':', ' ')
+//      val ret = ("echo ruok" #| nc_host)!!
+//      val zoo_run = if (ret == "imok") {
       dataStore = getDataStore(context)
       val sft = getSft(context)
       dataStore.createSchema(sft)
@@ -76,9 +76,9 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
       converter = getConverter(sft, context)
       featureWriter = createFeatureWriter(sft, context)
       getLogger.info(s"Initialized GeoMesaIngestProcessor datastore, fw, converter for type ${sft.getTypeName}")
-      } else {
-        getLogger.info("The Zookeepers in the GeoMesaIngestProcessor configuration are not running.")
-      }
+//      } else {
+//        getLogger.info("The Zookeepers in the GeoMesaIngestProcessor configuration are not running.")
+//      }
     } catch {
       case e: Exception =>
         getLogger.info("There is a configuration error with the ProcessContext.")

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -65,8 +65,7 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
     
     val zookeepers = context.getProperty(Zookeepers).getValue
     val nc_host = "nc " + zookeepers.replace(':', ' ')
-    val ret = ("echo ruok" #| nc_host)!!
-    if ret == "imok" {
+    if ret == "imok"
       dataStore = getDataStore(context)
       val sft = getSft(context)
       dataStore.createSchema(sft)
@@ -74,9 +73,8 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
       converter = getConverter(sft, context)
       featureWriter = createFeatureWriter(sft, context)
       getLogger.info(s"Initialized GeoMesaIngestProcessor datastore, fw, converter for type ${sft.getTypeName}")
-    } else {
+    else
       getLogger.info("The Zookeepers in the GeoMesaIngestProcessor configuration are not running.")
-    }
   }
 
   @OnStopped

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -63,9 +63,7 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
   @OnScheduled
   def initialize(context: ProcessContext): Unit = {
     
-    val zookeepers = context.getProperty(Zookeepers).getValue
-    val nc_host = "nc " + zookeepers.replace(':', ' ')
-    val ret = "echo ruok" #| nc_host !!
+    val ret = "imok"
     if (ret == "imok") {
       dataStore = getDataStore(context)
       val sft = getSft(context)

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -87,10 +87,15 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
 
   @OnStopped
   def cleanup(): Unit = {
-    IOUtils.closeQuietly(featureWriter)
-    featureWriter = null
-    dataStore = null
-    getLogger.info("Shut down geomesa processor")
+    try {
+      IOUtils.closeQuietly(featureWriter)
+      featureWriter = null
+      dataStore = null
+      getLogger.info("Shut down geomesa processor")
+    } catch {
+      case e: Exception =>
+        getLogger.info("There is a configuration error with the ProcessContext.")
+    }
   }
 
   override def getRelationships = relationships

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -81,6 +81,7 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
 //      }
     } catch {
       case e: Exception =>
+        featureWriter: SFW = null
         getLogger.info("There is a configuration error with the ProcessContext.")
     }
   }

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -68,17 +68,17 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
       val zookeepers = context.getProperty(Zookeepers).getValue
       val nc_host = "nc " + zookeepers.replace(':', ' ')
       val ret = ("echo ruok" #| nc_host)!!
-      val zoo_run = if (ret == "imok") {
-        dataStore = getDataStore(context)
-        val sft = getSft(context)
-        dataStore.createSchema(sft)
+//      val zoo_run = if (ret == "imok") {
+      dataStore = getDataStore(context)
+      val sft = getSft(context)
+      dataStore.createSchema(sft)
 
-        converter = getConverter(sft, context)
-        featureWriter = createFeatureWriter(sft, context)
-        getLogger.info(s"Initialized GeoMesaIngestProcessor datastore, fw, converter for type ${sft.getTypeName}")
-      } else {
-        getLogger.info("The Zookeepers in the GeoMesaIngestProcessor configuration are not running.")
-      }
+      converter = getConverter(sft, context)
+      featureWriter = createFeatureWriter(sft, context)
+      getLogger.info(s"Initialized GeoMesaIngestProcessor datastore, fw, converter for type ${sft.getTypeName}")
+//      } else {
+//        getLogger.info("The Zookeepers in the GeoMesaIngestProcessor configuration are not running.")
+//      }
     } catch {
       case e: Exception =>
         getLogger.info("There is a configuration error with the ProcessContext.")

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -65,7 +65,8 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
     
     val zookeepers = context.getProperty(Zookeepers).getValue
     val nc_host = "nc " + zookeepers.replace(':', ' ')
-    if ret == "imok"
+    ret = "imok"
+    if (ret == "imok")
       dataStore = getDataStore(context)
       val sft = getSft(context)
       dataStore.createSchema(sft)

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -65,7 +65,7 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
     
     val zookeepers = context.getProperty(Zookeepers).getValue
     val nc_host = "nc " + zookeepers.replace(':', ' ')
-    val ret = "imok"
+    val ret = "echo ruok" #| nc_host !!
     if (ret == "imok") {
       dataStore = getDataStore(context)
       val sft = getSft(context)

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -66,7 +66,7 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
     val zookeepers = context.getProperty(Zookeepers).getValue
     val nc_host = "nc " + zookeepers.replace(':', ' ')
     val ret = ("echo ruok" #| nc_host)!!
-    if (ret == "imok") {
+    if ret == "imok" {
       dataStore = getDataStore(context)
       val sft = getSft(context)
       dataStore.createSchema(sft)

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -88,13 +88,15 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
   @OnStopped
   def cleanup(): Unit = {
     try {
+      featureWriter.close()
+    } catch {
+      case e: Exception =>
+        getLogger.info("There was an error trying to STOP the processor and close the feature.  This may mean the associated zookeepers could not be connected to.")
+    } finally {
       IOUtils.closeQuietly(featureWriter)
       featureWriter = null
       dataStore = null
       getLogger.info("Shut down geomesa processor")
-    } catch {
-      case e: Exception =>
-        getLogger.info("There is a configuration error with the ProcessContext.")
     }
   }
 

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -63,6 +63,7 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
   @OnScheduled
   def initialize(context: ProcessContext): Unit = {
 
+//Added Try and ruok error-checking here
     try {    
       val zookeepers = context.getProperty(Zookeepers).getValue
       val nc_host = "nc " + zookeepers.replace(':', ' ')

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -65,9 +65,9 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
 
 //Added Try and ruok error-checking here
     try {    
-      val zookeepers = context.getProperty(Zookeepers).getValue
-      val nc_host = "nc " + zookeepers.replace(':', ' ')
-      val ret = ("echo ruok" #| nc_host)!!
+//      val zookeepers = context.getProperty(Zookeepers).getValue
+//      val nc_host = "nc " + zookeepers.replace(':', ' ')
+//      val ret = ("echo ruok" #| nc_host)!!
 //      val zoo_run = if (ret == "imok") {
       dataStore = getDataStore(context)
       val sft = getSft(context)

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -65,7 +65,7 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
     
     val zookeepers = context.getProperty(Zookeepers).getValue
     val nc_host = "nc " + zookeepers.replace(':', ' ')
-    val ret = "imok"
+    val ret = ("echo ruok" #| nc_host)!!
     val zoo_run = if (ret == "imok") {
       dataStore = getDataStore(context)
       val sft = getSft(context)

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -62,20 +62,25 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
 
   @OnScheduled
   def initialize(context: ProcessContext): Unit = {
-    
-    val zookeepers = context.getProperty(Zookeepers).getValue
-    val nc_host = "nc " + zookeepers.replace(':', ' ')
-    val ret = ("echo ruok" #| nc_host)!!
-    val zoo_run = if (ret == "imok") {
-      dataStore = getDataStore(context)
-      val sft = getSft(context)
-      dataStore.createSchema(sft)
 
-      converter = getConverter(sft, context)
-      featureWriter = createFeatureWriter(sft, context)
-      getLogger.info(s"Initialized GeoMesaIngestProcessor datastore, fw, converter for type ${sft.getTypeName}")
-    } else {
-      getLogger.info("The Zookeepers in the GeoMesaIngestProcessor configuration are not running.")
+    try {    
+      val zookeepers = context.getProperty(Zookeepers).getValue
+      val nc_host = "nc " + zookeepers.replace(':', ' ')
+      val ret = ("echo ruok" #| nc_host)!!
+      val zoo_run = if (ret == "imok") {
+        dataStore = getDataStore(context)
+        val sft = getSft(context)
+        dataStore.createSchema(sft)
+
+        converter = getConverter(sft, context)
+        featureWriter = createFeatureWriter(sft, context)
+        getLogger.info(s"Initialized GeoMesaIngestProcessor datastore, fw, converter for type ${sft.getTypeName}")
+      } else {
+        getLogger.info("The Zookeepers in the GeoMesaIngestProcessor configuration are not running.")
+      }
+    } catch {
+      case e: Exception =>
+        getLogger.info("There is a configuration error with the ProcessContext.")
     }
   }
 

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -65,10 +65,10 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
 
 //Added Try and ruok error-checking here
     try {    
-//      val zookeepers = context.getProperty(Zookeepers).getValue
-//      val nc_host = "nc " + zookeepers.replace(':', ' ')
-//      val ret = ("echo ruok" #| nc_host)!!
-//      val zoo_run = if (ret == "imok") {
+      val zookeepers = context.getProperty(Zookeepers).getValue
+      val nc_host = "nc " + zookeepers.replace(':', ' ')
+      val ret = ("echo ruok" #| nc_host)!!
+      val zoo_run = if (ret == "imok") {
       dataStore = getDataStore(context)
       val sft = getSft(context)
       dataStore.createSchema(sft)
@@ -76,9 +76,9 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
       converter = getConverter(sft, context)
       featureWriter = createFeatureWriter(sft, context)
       getLogger.info(s"Initialized GeoMesaIngestProcessor datastore, fw, converter for type ${sft.getTypeName}")
-//      } else {
-//        getLogger.info("The Zookeepers in the GeoMesaIngestProcessor configuration are not running.")
-//      }
+      } else {
+        getLogger.info("The Zookeepers in the GeoMesaIngestProcessor configuration are not running.")
+      }
     } catch {
       case e: Exception =>
         getLogger.info("There is a configuration error with the ProcessContext.")

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -65,7 +65,7 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
     
     val zookeepers = context.getProperty(Zookeepers).getValue
     val nc_host = "nc " + zookeepers.replace(':', ' ')
-    val ret = "echo ruok" #| nc_host !!
+    val ret = ("echo ruok" #| nc_host)!!
     if (ret == "imok") {
       dataStore = getDataStore(context)
       val sft = getSft(context)

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -81,7 +81,7 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
 //      }
     } catch {
       case e: Exception =>
-        featureWriter: SFW = null
+        featureWriter = null
         getLogger.info("There is a configuration error with the ProcessContext.")
     }
   }

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -63,6 +63,8 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
   @OnScheduled
   def initialize(context: ProcessContext): Unit = {
     
+    val zookeepers = context.getProperty(Zookeepers).getValue
+    val nc_host = "nc " + zookeepers.replace(':', ' ')
     val ret = "imok"
     if (ret == "imok") {
       dataStore = getDataStore(context)

--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -65,8 +65,8 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
     
     val zookeepers = context.getProperty(Zookeepers).getValue
     val nc_host = "nc " + zookeepers.replace(':', ' ')
-    ret = "imok"
-    if (ret == "imok")
+    val ret = "imok"
+    val zoo_run = if (ret == "imok") {
       dataStore = getDataStore(context)
       val sft = getSft(context)
       dataStore.createSchema(sft)
@@ -74,8 +74,9 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
       converter = getConverter(sft, context)
       featureWriter = createFeatureWriter(sft, context)
       getLogger.info(s"Initialized GeoMesaIngestProcessor datastore, fw, converter for type ${sft.getTypeName}")
-    else
+    } else {
       getLogger.info("The Zookeepers in the GeoMesaIngestProcessor configuration are not running.")
+    }
   }
 
   @OnStopped


### PR DESCRIPTION
GeoMesaIngestProcessors hang if they are RUNNING and can't connect to Accumulo/Zookeepers.  Added Try and error checking in GeoMesaIngestProcessor.scala to address this.