### PR TITLE
GeoMesaIngestProcessor hang fix.

### DIFF
--- a/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/locationtech/geomesa/nifi/GeoMesaIngestProcessor.scala
@@ -92,6 +92,7 @@ class GeoMesaIngestProcessor extends AbstractProcessor {
       featureWriter.close()
     } catch {
       case e: Exception =>
+        featureWriter = null
         getLogger.info("There was an error trying to STOP the processor and close the feature.  This may mean the associated zookeepers could not be connected to.")
     } finally {
       IOUtils.closeQuietly(featureWriter)


### PR DESCRIPTION
GeoMesaIngestProcessor will hang on the following conditions:
1) Processor instantiated in nifi.
2) Properties configured for zookeepers.
3) Zookeepers are NOT up and running.
4) Processor is started.
5) Attempt to stop the processor (through the console or nifi-api).
A single processor has been observed to take 1-2 minutes to stop under these conditions.  Trying to stop multiple processors in this condition can cause nifi to fail fatally and potentially remain in the failed state after nifi is restarted.
With the fix, the processor should immediately stop if zookeepers are not present, by setting "featureWriter = null" if an exception was encountered (@onScheduled) while trying to obtain the session.